### PR TITLE
Графон из бэк

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -202,7 +202,7 @@
 	sleep(10)
 	enter_allowed = 0
 	if(ticker)
-		//ticker.station_explosion_cinematic(0,null)
+		ticker.station_explosion_cinematic(0,null)
 		if(malf_turf)
 			sleep(20)
 			explosion(malf_turf, 15, 70, 200)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -502,7 +502,7 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user)
 			if(syndie_location)
 				ticker.mode:syndies_didnt_escape = (syndie_location.z > ZLEVEL_STATION ? 0 : 1)	//muskets will make me change this, but it will do for now
 			ticker.mode:nuke_off_station = off_station
-		//ticker.station_explosion_cinematic(off_station,null)
+			ticker.station_explosion_cinematic(off_station,null)
 		if(ticker.mode)
 			ticker.mode.explosion_in_progress = 0
 			if(ticker.mode.name == "nuclear emergency")


### PR DESCRIPTION
Возвращаем графон в режимах Нюка и малф.
Насчет малфа уверен на 90%, затестить не удалось из-за отказа ССки мне его стартовать даже с танцами с бубном, хотя там же, как и в нюкебомбе стояли // перед нужной строчкой. Должно работать.
Можно посмотреть что там со взрывом нюкабомбы при других режимах, кроме нюки и малфа, ибо там работать не будет.
Смотрите, в общем.